### PR TITLE
Minor enhancements

### DIFF
--- a/lib/systemd/system/rockpi-poe.service
+++ b/lib/systemd/system/rockpi-poe.service
@@ -3,8 +3,8 @@ Description=Rockpi PoE-FAN
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/bin/rockpi-poe.py start
-ExecStop=/usr/bin/python3 /usr/bin/rockpi-poe.py stop
+ExecStart=/usr/bin/python3 -u /usr/bin/rockpi-poe.py start
+ExecStop=/usr/bin/python3 -u /usr/bin/rockpi-poe.py stop
 Restart=on-failure
 
 [Install]

--- a/usr/bin/rockpi-poe.py
+++ b/usr/bin/rockpi-poe.py
@@ -99,19 +99,19 @@ def turn_on():
     while True:
         t = read_temp()
         if t >= conf['lv3']:
-            print('100%')
+            print('PoE Fan speed 100%')
             change_dc(0.0)
         elif t >= conf['lv2']:
-            print('75%')
+            print('PoE Fan speed 75%')
             change_dc(0.25)
         elif t >= conf['lv1']:
-            print('50%')
+            print('PoE Fan speed 50%')
             change_dc(0.5)
         elif t >= conf['lv0']:
-            print('25%')
+            print('PoE Fan speed 25%')
             change_dc(0.75)
         else:
-            print('turn off')
+            print('PoE Fan off')
             change_dc(1.0)
         time.sleep(10)
 


### PR DESCRIPTION
two minor cosmetic enhancements.  No functional changes.  
1) select unbuffered output in systemd service.  
2) make the poe script output more descriptive.  Preface percentage with 'PoE Fan speed'  New format is:

Mar 26 11:56:37 funky python3[47449]: PoE Fan speed 25%
Mar 26 11:56:47 funky python3[47449]: PoE Fan speed 25%
Mar 26 11:56:57 funky python3[47449]: PoE Fan speed 25%

Thank you.